### PR TITLE
mosaic_dask_presets: Ev6 scheduler tiers + n_sims-aware sizing (supersedes #115, v0.60.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: MOSAIC
 Type: Package
 Title: Metapopulation Outbreak Simulation And Interventions for Cholera (MOSAIC)
-Version: 0.60.0
-Date: 2026-07-01
+Version: 0.60.1
+Date: 2026-07-08
 Authors@R: c(
           person("John R", "Giles",
                  email = "john.giles@gatesfoundation.org",

--- a/R/presets.R
+++ b/R/presets.R
@@ -67,6 +67,16 @@ mosaic_io_presets <- function(preset = c("default", "debug", "fast", "archive"))
 #' @param n_workers Integer between 1 and 500 inclusive. The number of
 #'   LASER worker VMs to provision. Each runs one cholera sim
 #'   concurrently. Non-integer values are rounded.
+#' @param n_sims Optional positive integer: the number of simulations
+#'   submitted per Dask batch (the largest \code{n_simulations} the run
+#'   will use). When supplied, the scheduler VM is sized to the LARGER of
+#'   the worker-count tier and the sim-volume tier (see Details). This
+#'   matters because the Dask path submits ALL \code{n_sims} futures and
+#'   gathers them in a single blocking call, so the scheduler holds the
+#'   whole batch's task graph + results in RAM at once — a memory load
+#'   driven by \code{n_sims}, not \code{n_workers}. Leave \code{NULL}
+#'   (default) to size the scheduler by \code{n_workers} alone, assuming
+#'   the typical ~120 sims/worker batch. Non-integer values are rounded.
 #'
 #' @return Named list ready to pass as the \code{dask_spec} argument of
 #'   \code{\link{run_MOSAIC}}.
@@ -82,17 +92,42 @@ mosaic_io_presets <- function(preset = c("default", "debug", "fast", "archive"))
 #'     / 8 GiB. The cholera sim is single-threaded GIL-bound Python, so
 #'     larger VMs would idle cores; the second vCPU absorbs Dask
 #'     plumbing (network I/O, nanny, heartbeats).
-#'   \item \strong{Scheduler VM} — 5-tier graduation by worker count:
-#'     \tabular{ll}{
-#'       \code{n_workers <= 50}   \tab \code{Standard_D2s_v6}   (2 vCPU /   8 GiB) \cr
-#'       \code{n_workers <= 100}  \tab \code{Standard_D4s_v6}   (4 vCPU /  16 GiB) \cr
-#'       \code{n_workers <= 200}  \tab \code{Standard_D8s_v6}   (8 vCPU /  32 GiB) \cr
-#'       \code{n_workers <= 350}  \tab \code{Standard_D16s_v6} (16 vCPU /  64 GiB) \cr
-#'       \code{n_workers >  350}  \tab \code{Standard_D32s_v6} (32 vCPU / 128 GiB) \cr
+#'   \item \strong{Scheduler VM} — memory-optimized \strong{Ev6} family
+#'     (Emerald Rapids, 8 GiB/vCPU vs Dsv6's 4), sized to the LARGER of two
+#'     5-tier ladders: one keyed on \code{n_workers}, one on \code{n_sims}
+#'     (only when supplied). The scheduler is RAM-bound, not CPU-bound: the
+#'     Dask calibration path submits every one of the batch's \code{n_sims}
+#'     futures, keeps them all alive, and gathers them in a SINGLE blocking
+#'     call, so the scheduler holds the whole batch's task graph (the
+#'     per-sim JSON params are embedded in each task spec) plus the
+#'     in-transit results at once. That memory load scales with
+#'     \code{n_sims} (result/graph volume), only weakly with
+#'     \code{n_workers} (heartbeats/comms) — hence the two ladders.
+#'     Scheduler-VM cost is negligible next to a 50-500 worker fleet, so
+#'     the tiers err toward headroom; an under-sized scheduler that OOMs
+#'     (exit 137) kills the entire multi-hour run. A 200-worker run OOM'd a
+#'     general-purpose \code{Standard_D8s_v6} (32 GiB) under fast-turnover
+#'     calibration, which is why the ladder is on the memory-optimized
+#'     family.
+#'
+#'     Shared SKU ladder (tier -> VM -> RAM):
+#'     \tabular{lll}{
+#'       tier 1 \tab \code{Standard_E4s_v6}  \tab ( 4 vCPU /  32 GiB) \cr
+#'       tier 2 \tab \code{Standard_E8s_v6}  \tab ( 8 vCPU /  64 GiB) \cr
+#'       tier 3 \tab \code{Standard_E16s_v6} \tab (16 vCPU / 128 GiB) \cr
+#'       tier 4 \tab \code{Standard_E32s_v6} \tab (32 vCPU / 256 GiB) \cr
+#'       tier 5 \tab \code{Standard_E64s_v6} \tab (64 vCPU / 512 GiB) \cr
 #'     }
-#'     Scheduler is mostly connection / task-graph state, not CPU-bound.
-#'     Finer tiers avoid over-provisioning at low worker counts while
-#'     keeping RAM headroom at high counts.
+#'     \code{n_workers} -> tier: \code{<=50} t1; \code{<=100} t2;
+#'     \code{<=200} t3; \code{<=350} t4; \code{>350} t5. \code{n_sims} ->
+#'     tier (when set): \code{<=10000} t1; \code{<=25000} t2;
+#'     \code{<=50000} t3; \code{<=100000} t4; \code{>100000} t5. The floor
+#'     is 32 GiB (never the old 8 GiB D2s, which is indefensible for a
+#'     gather-everything design). Note: Coiled/Dask schedulers do NOT spill
+#'     to disk, so a bigger VM — not a memory-limit option — is the only
+#'     OOM guard; that is why this helper sizes the SKU rather than passing
+#'     \code{scheduler_options}. Standard Esv6 quota in westus2 (IDM
+#'     Research 2) is ample; no quota increase needed for these tiers.
 #'   \item \strong{wait_for_workers} — absolute number of workers that
 #'     must be up before tasks dispatch. Equivalent to 80\% of the
 #'     pool at \code{n_workers <= 250}, 90\% above, floored at 1.
@@ -112,7 +147,8 @@ mosaic_io_presets <- function(preset = c("default", "debug", "fast", "archive"))
 #' }
 #'
 #' \strong{Sizing guide} (~0.7 s per LASER iteration measured on ETH
-#' single-location):
+#' single-location). Pass \code{n_sims} to size the scheduler to the
+#' batch you actually submit:
 #' \itemize{
 #'   \item \code{n_workers = 25-50}: smoke tests, 1-5K sims, day-to-day.
 #'   \item \code{n_workers = 125}: typical 10K-sim fixed-budget calibrations.
@@ -120,6 +156,12 @@ mosaic_io_presets <- function(preset = c("default", "debug", "fast", "archive"))
 #'   \item \code{n_workers = 500}: run_10-class jobs (60K+ sims). At the
 #'     workspace 1,000-core cap.
 #' }
+#' If a batch runs many sims on relatively few workers (e.g. a 30K-sim
+#' predictive batch on 40 workers), the \code{n_workers} tier alone
+#' under-sizes the scheduler and it can OOM; pass
+#' \code{mosaic_dask_presets(40, n_sims = 30000)} so the scheduler is
+#' sized to the 30K-sim tier (64 GiB) instead of the 40-worker tier
+#' (16 GiB).
 #'
 #' \strong{Notes:}
 #' \itemize{
@@ -158,6 +200,10 @@ mosaic_io_presets <- function(preset = c("default", "debug", "fast", "archive"))
 #'   dask_spec  = mosaic_dask_presets(n_workers = 125)
 #' )
 #'
+#' # Many sims on few workers: size the scheduler to the batch, not the
+#' # worker count, to avoid a scheduler OOM (exit 137).
+#' spec <- mosaic_dask_presets(n_workers = 40, n_sims = 30000)
+#'
 #' # Max cluster with spot VMs for a long adaptive run
 #' spec <- mosaic_dask_presets(500)
 #' spec$spot_policy <- "spot_with_fallback"
@@ -168,7 +214,7 @@ mosaic_io_presets <- function(preset = c("default", "debug", "fast", "archive"))
 #' }
 #'
 #' @export
-mosaic_dask_presets <- function(n_workers) {
+mosaic_dask_presets <- function(n_workers, n_sims = NULL) {
   if (missing(n_workers) || !is.numeric(n_workers) || length(n_workers) != 1L ||
       is.na(n_workers) || !is.finite(n_workers)) {
     stop("`n_workers` must be a single numeric value between 1 and 500",
@@ -179,16 +225,57 @@ mosaic_dask_presets <- function(n_workers) {
     stop(sprintf("`n_workers` must be in [1, 500]; got %d", n_workers),
          call. = FALSE)
   }
+  if (!is.null(n_sims)) {
+    if (!is.numeric(n_sims) || length(n_sims) != 1L || is.na(n_sims) ||
+        !is.finite(n_sims) || n_sims < 1) {
+      stop("`n_sims` must be NULL or a single positive integer", call. = FALSE)
+    }
+    n_sims <- as.integer(round(n_sims))
+  }
 
-  # 5-tier scheduler graduation. Scheduler is connection/task-graph
-  # state, not CPU-bound — these sizes give RAM headroom for the
-  # task graph (~5 KiB per task) without over-provisioning at low N.
-  scheduler_vm <-
-    if      (n_workers <=  50L) "Standard_D2s_v6"   #  2 vCPU /   8 GiB
-    else if (n_workers <= 100L) "Standard_D4s_v6"   #  4 vCPU /  16 GiB
-    else if (n_workers <= 200L) "Standard_D8s_v6"   #  8 vCPU /  32 GiB
-    else if (n_workers <= 350L) "Standard_D16s_v6"  # 16 vCPU /  64 GiB
-    else                        "Standard_D32s_v6"  # 32 vCPU / 128 GiB
+  # Scheduler VM sizing on the memory-optimized Ev6 family (Emerald Rapids,
+  # 8 GiB/vCPU vs Dsv6's 4). The scheduler is RAM-bound, not CPU-bound: the
+  # Dask calibration path submits every one of the batch's n_sims futures,
+  # keeps them all alive, and gathers them in a SINGLE blocking call, so the
+  # scheduler holds the whole batch's task graph (per-sim JSON params are
+  # embedded in each task spec) plus the in-transit results at once. That
+  # load scales with n_sims (result/graph volume), only weakly with
+  # n_workers (heartbeats/comms). We size to the LARGER of a worker-count
+  # tier and a sim-volume tier. Floor is 32 GiB (never the old 8 GiB D2s,
+  # indefensible for a gather-everything design); a 200-worker run OOM'd a
+  # D8s_v6 (32 GiB) under fast turnover, which is why we moved to the
+  # memory-optimized family. Coiled/Dask schedulers do NOT spill to disk,
+  # so a bigger VM is the only OOM guard.
+  scheduler_ladder <- c(
+    "Standard_E4s_v6",   # tier 1:  4 vCPU /  32 GiB
+    "Standard_E8s_v6",   # tier 2:  8 vCPU /  64 GiB
+    "Standard_E16s_v6",  # tier 3: 16 vCPU / 128 GiB
+    "Standard_E32s_v6",  # tier 4: 32 vCPU / 256 GiB
+    "Standard_E64s_v6"   # tier 5: 64 vCPU / 512 GiB
+  )
+
+  # Worker-count tier. This is the safe default that fixed the observed
+  # 200-worker OOM (tier 3 = 128 GiB). n_sims (below) can push the tier
+  # higher for a many-sims/few-workers batch, but never lower.
+  tier_workers <-
+    if      (n_workers <=  50L) 1L
+    else if (n_workers <= 100L) 2L
+    else if (n_workers <= 200L) 3L
+    else if (n_workers <= 350L) 4L
+    else                        5L
+
+  # Sim-volume tier (0L => not supplied; contributes nothing to the max).
+  tier_sims <- 0L
+  if (!is.null(n_sims)) {
+    tier_sims <-
+      if      (n_sims <=  10000L) 1L
+      else if (n_sims <=  25000L) 2L
+      else if (n_sims <=  50000L) 3L
+      else if (n_sims <= 100000L) 4L
+      else                        5L
+  }
+
+  scheduler_vm <- scheduler_ladder[[max(tier_workers, tier_sims)]]
 
   # wait_for_workers: hold submission until this many workers are up.
   # Coiled's 0.3-default penalizes short-task calibrations (first sims
@@ -226,14 +313,16 @@ mosaic_dask_presets <- function(n_workers) {
     worker_options     = list(nthreads = 1L),
     n_workers          = n_workers,
     # Three equivalent 2-vCPU x86 variants + one 4-vCPU fallback. Coiled
-    # picks the cheapest available, so the D2 variants are tried first (D2s_v6
-    # is the most-requested 2-vCPU on Azure and most likely to face
-    # regional-contention shortages); D4s_v6 (4 vCPU / 16 GB) is added as a
-    # last-resort backup when no D2 SKU is available in westus2. The 1
-    # thread/worker config (worker_options below) means the extra cores aren't
-    # used for parallelism — D4 is purely an availability hedge, not a
-    # capacity bump. If a run consistently OOMs on D2, set vm_types
-    # explicitly to the D4 list rather than relying on this fallback.
+    # honours LIST ORDER as decreasing priority (not cost-based auto-select),
+    # so the D2 variants are tried first and D4s_v6 (4 vCPU / 16 GB) is only
+    # used as a last-resort backup when NO D2 SKU is available in westus2
+    # (D2s_v6 is the most-requested 2-vCPU on Azure and most likely to hit
+    # regional-contention shortages). The 1 thread/worker config
+    # (worker_options below) means the extra cores aren't used for
+    # parallelism — D4 is purely an availability (and RAM) hedge, not a
+    # capacity bump, and because it is last it never displaces an available
+    # D2. If a run consistently OOMs on D2, set vm_types explicitly to the
+    # D4 list rather than relying on this fallback.
     vm_types           = c(
       "Standard_D2s_v6",   # Intel Emerald Rapids               (cheapest)
       "Standard_D2ds_v6",  # Intel Emerald Rapids w/ local SSD

--- a/man/mosaic_dask_presets.Rd
+++ b/man/mosaic_dask_presets.Rd
@@ -4,12 +4,23 @@
 \alias{mosaic_dask_presets}
 \title{Get an Optimal Dask/Coiled Cluster Spec for a Given Worker Count}
 \usage{
-mosaic_dask_presets(n_workers)
+mosaic_dask_presets(n_workers, n_sims = NULL)
 }
 \arguments{
 \item{n_workers}{Integer between 1 and 500 inclusive. The number of
 LASER worker VMs to provision. Each runs one cholera sim
 concurrently. Non-integer values are rounded.}
+
+\item{n_sims}{Optional positive integer: the number of simulations
+submitted per Dask batch (the largest \code{n_simulations} the run
+will use). When supplied, the scheduler VM is sized to the LARGER of
+the worker-count tier and the sim-volume tier (see Details). This
+matters because the Dask path submits ALL \code{n_sims} futures and
+gathers them in a single blocking call, so the scheduler holds the
+whole batch's task graph + results in RAM at once — a memory load
+driven by \code{n_sims}, not \code{n_workers}. Leave \code{NULL}
+(default) to size the scheduler by \code{n_workers} alone, assuming
+the typical ~120 sims/worker batch. Non-integer values are rounded.}
 }
 \value{
 Named list ready to pass as the \code{dask_spec} argument of
@@ -34,17 +45,44 @@ Rapids), \code{Standard_D2ds_v6} (same Intel with local SSD),
 / 8 GiB. The cholera sim is single-threaded GIL-bound Python, so
 larger VMs would idle cores; the second vCPU absorbs Dask
 plumbing (network I/O, nanny, heartbeats).
-\item \strong{Scheduler VM} — 5-tier graduation by worker count:
-\tabular{ll}{
-\code{n_workers <= 50}   \tab \code{Standard_D2s_v6}   (2 vCPU /   8 GiB) \cr
-\code{n_workers <= 100}  \tab \code{Standard_D4s_v6}   (4 vCPU /  16 GiB) \cr
-\code{n_workers <= 200}  \tab \code{Standard_D8s_v6}   (8 vCPU /  32 GiB) \cr
-\code{n_workers <= 350}  \tab \code{Standard_D16s_v6} (16 vCPU /  64 GiB) \cr
-\code{n_workers >  350}  \tab \code{Standard_D32s_v6} (32 vCPU / 128 GiB) \cr
-}
-Scheduler is mostly connection / task-graph state, not CPU-bound.
-Finer tiers avoid over-provisioning at low worker counts while
-keeping RAM headroom at high counts.
+\item \strong{Scheduler VM} — memory-optimized \strong{Ev6} family
+(Emerald Rapids, 8 GiB/vCPU vs Dsv6's 4), sized to the LARGER of two
+5-tier ladders: one keyed on \code{n_workers}, one on \code{n_sims}
+(only when supplied). The scheduler is RAM-bound, not CPU-bound: the
+Dask calibration path submits every one of the batch's \code{n_sims}
+futures, keeps them all alive, and gathers them in a SINGLE blocking
+call, so the scheduler holds the whole batch's task graph (the
+per-sim JSON params are embedded in each task spec) plus the
+in-transit results at once. That memory load scales with
+\code{n_sims} (result/graph volume), only weakly with
+\code{n_workers} (heartbeats/comms) — hence the two ladders.
+Scheduler-VM cost is negligible next to a 50-500 worker fleet, so
+the tiers err toward headroom; an under-sized scheduler that OOMs
+(exit 137) kills the entire multi-hour run. A 200-worker run OOM'd a
+general-purpose \code{Standard_D8s_v6} (32 GiB) under fast-turnover
+calibration, which is why the ladder is on the memory-optimized
+family.
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{Shared SKU ladder (tier -> VM -> RAM):
+\\tabular\{lll\}\{
+  tier 1 \\tab \code{Standard_E4s_v6}  \\tab ( 4 vCPU /  32 GiB) \\cr
+  tier 2 \\tab \code{Standard_E8s_v6}  \\tab ( 8 vCPU /  64 GiB) \\cr
+  tier 3 \\tab \code{Standard_E16s_v6} \\tab (16 vCPU / 128 GiB) \\cr
+  tier 4 \\tab \code{Standard_E32s_v6} \\tab (32 vCPU / 256 GiB) \\cr
+  tier 5 \\tab \code{Standard_E64s_v6} \\tab (64 vCPU / 512 GiB) \\cr
+\}
+\code{n_workers} -> tier: \code{<=50} t1; \code{<=100} t2;
+\code{<=200} t3; \code{<=350} t4; \code{>350} t5. \code{n_sims} ->
+tier (when set): \code{<=10000} t1; \code{<=25000} t2;
+\code{<=50000} t3; \code{<=100000} t4; \code{>100000} t5. The floor
+is 32 GiB (never the old 8 GiB D2s, which is indefensible for a
+gather-everything design). Note: Coiled/Dask schedulers do NOT spill
+to disk, so a bigger VM — not a memory-limit option — is the only
+OOM guard; that is why this helper sizes the SKU rather than passing
+\code{scheduler_options}. Standard Esv6 quota in westus2 (IDM
+Research 2) is ample; no quota increase needed for these tiers.
+}\if{html}{\out{</div>}}
+
 \item \strong{wait_for_workers} — absolute number of workers that
 must be up before tasks dispatch. Equivalent to 80\\% of the
 pool at \code{n_workers <= 250}, 90\\% above, floored at 1.
@@ -64,7 +102,8 @@ Override globally without forking the helper by setting
 }
 
 \strong{Sizing guide} (~0.7 s per LASER iteration measured on ETH
-single-location):
+single-location). Pass \code{n_sims} to size the scheduler to the
+batch you actually submit:
 \itemize{
 \item \code{n_workers = 25-50}: smoke tests, 1-5K sims, day-to-day.
 \item \code{n_workers = 125}: typical 10K-sim fixed-budget calibrations.
@@ -72,6 +111,12 @@ single-location):
 \item \code{n_workers = 500}: run_10-class jobs (60K+ sims). At the
 workspace 1,000-core cap.
 }
+If a batch runs many sims on relatively few workers (e.g. a 30K-sim
+predictive batch on 40 workers), the \code{n_workers} tier alone
+under-sizes the scheduler and it can OOM; pass
+\code{mosaic_dask_presets(40, n_sims = 30000)} so the scheduler is
+sized to the 30K-sim tier (64 GiB) instead of the 40-worker tier
+(16 GiB).
 
 \strong{Notes:}
 \itemize{
@@ -106,6 +151,10 @@ result <- run_MOSAIC(
   ),
   dask_spec  = mosaic_dask_presets(n_workers = 125)
 )
+
+# Many sims on few workers: size the scheduler to the batch, not the
+# worker count, to avoid a scheduler OOM (exit 137).
+spec <- mosaic_dask_presets(n_workers = 40, n_sims = 30000)
 
 # Max cluster with spot VMs for a long adaptive run
 spec <- mosaic_dask_presets(500)

--- a/tests/testthat/test-presets.R
+++ b/tests/testthat/test-presets.R
@@ -1,0 +1,104 @@
+test_that("mosaic_dask_presets() backward-compatible single-arg call returns a valid spec", {
+  spec <- mosaic_dask_presets(125)
+  expect_type(spec, "list")
+  expect_identical(spec$type, "coiled")
+  expect_identical(spec$n_workers, 125L)
+  expect_true(is.character(spec$scheduler_vm_types))
+  expect_length(spec$scheduler_vm_types, 1L)
+  expect_true(all(c("Standard_D2s_v6", "Standard_D2ds_v6",
+                    "Standard_D2ads_v6", "Standard_D4s_v6") %in% spec$vm_types))
+  expect_true(spec$wait_for_workers >= 1L)
+  expect_true(spec$timeout >= 1800L)
+})
+
+test_that("mosaic_dask_presets() scheduler floor is 32 GiB on Ev6, never the old 8 GiB D2s (OOM regression)", {
+  # The gather-everything Dask path holds the whole batch on the scheduler,
+  # so an 8 GiB (Standard_D2s_v6) scheduler is indefensible. Smallest tier
+  # must be Standard_E4s_v6 (32 GiB) on the memory-optimized Ev6 family.
+  for (nw in c(1L, 10L, 50L)) {
+    spec <- mosaic_dask_presets(nw)
+    expect_identical(spec$scheduler_vm_types, "Standard_E4s_v6",
+                     info = sprintf("n_workers = %d", nw))
+    expect_false("Standard_D2s_v6" %in% spec$scheduler_vm_types)
+  }
+})
+
+test_that("mosaic_dask_presets() worker-count scheduler ladder graduates as documented", {
+  expect_identical(mosaic_dask_presets(50)$scheduler_vm_types,  "Standard_E4s_v6")
+  expect_identical(mosaic_dask_presets(51)$scheduler_vm_types,  "Standard_E8s_v6")
+  expect_identical(mosaic_dask_presets(100)$scheduler_vm_types, "Standard_E8s_v6")
+  expect_identical(mosaic_dask_presets(101)$scheduler_vm_types, "Standard_E16s_v6")
+  expect_identical(mosaic_dask_presets(200)$scheduler_vm_types, "Standard_E16s_v6")
+  expect_identical(mosaic_dask_presets(201)$scheduler_vm_types, "Standard_E32s_v6")
+  expect_identical(mosaic_dask_presets(350)$scheduler_vm_types, "Standard_E32s_v6")
+  expect_identical(mosaic_dask_presets(351)$scheduler_vm_types, "Standard_E64s_v6")
+  expect_identical(mosaic_dask_presets(500)$scheduler_vm_types, "Standard_E64s_v6")
+})
+
+test_that("mosaic_dask_presets() sizes the scheduler up for many sims on few workers (OOM fix)", {
+  # 40 workers alone would give tier 1 (32 GiB); a 30K-sim batch must lift
+  # the scheduler to the 50K-sim tier (128 GiB) so it does not OOM on gather.
+  base <- mosaic_dask_presets(40)
+  expect_identical(base$scheduler_vm_types, "Standard_E4s_v6")   # 32 GiB
+
+  big  <- mosaic_dask_presets(40, n_sims = 30000)
+  expect_identical(big$scheduler_vm_types, "Standard_E16s_v6")  # 128 GiB
+})
+
+test_that("mosaic_dask_presets() n_sims ladder maps to the documented tiers", {
+  # Hold n_workers at its floor tier so n_sims drives the result.
+  expect_identical(mosaic_dask_presets(1, n_sims = 10000)$scheduler_vm_types,  "Standard_E4s_v6")
+  expect_identical(mosaic_dask_presets(1, n_sims = 10001)$scheduler_vm_types,  "Standard_E8s_v6")
+  expect_identical(mosaic_dask_presets(1, n_sims = 25000)$scheduler_vm_types,  "Standard_E8s_v6")
+  expect_identical(mosaic_dask_presets(1, n_sims = 25001)$scheduler_vm_types,  "Standard_E16s_v6")
+  expect_identical(mosaic_dask_presets(1, n_sims = 50000)$scheduler_vm_types,  "Standard_E16s_v6")
+  expect_identical(mosaic_dask_presets(1, n_sims = 50001)$scheduler_vm_types,  "Standard_E32s_v6")
+  expect_identical(mosaic_dask_presets(1, n_sims = 100000)$scheduler_vm_types, "Standard_E32s_v6")
+  expect_identical(mosaic_dask_presets(1, n_sims = 100001)$scheduler_vm_types, "Standard_E64s_v6")
+})
+
+test_that("mosaic_dask_presets() takes the LARGER of the worker and sim tiers", {
+  # Big worker count, tiny n_sims: worker tier wins (not lowered by sims).
+  spec <- mosaic_dask_presets(200, n_sims = 100)
+  expect_identical(spec$scheduler_vm_types, "Standard_E16s_v6")  # tier 3 from workers
+  # Small worker count, huge n_sims: sim tier wins (not lowered by workers).
+  spec2 <- mosaic_dask_presets(60, n_sims = 200000)
+  expect_identical(spec2$scheduler_vm_types, "Standard_E64s_v6") # tier 5 from sims
+})
+
+test_that("mosaic_dask_presets() validates n_workers bounds", {
+  expect_error(mosaic_dask_presets(), "n_workers")
+  expect_error(mosaic_dask_presets(0), "\\[1, 500\\]")
+  expect_error(mosaic_dask_presets(501), "\\[1, 500\\]")
+  expect_error(mosaic_dask_presets("x"), "n_workers")
+  expect_error(mosaic_dask_presets(NA), "n_workers")
+})
+
+test_that("mosaic_dask_presets() validates n_sims", {
+  expect_error(mosaic_dask_presets(50, n_sims = 0),   "n_sims")
+  expect_error(mosaic_dask_presets(50, n_sims = -5),  "n_sims")
+  expect_error(mosaic_dask_presets(50, n_sims = NA),  "n_sims")
+  expect_error(mosaic_dask_presets(50, n_sims = c(1, 2)), "n_sims")
+  # NULL is the default and must be accepted.
+  expect_silent(mosaic_dask_presets(50, n_sims = NULL))
+  # Non-integer is rounded, not rejected.
+  expect_identical(mosaic_dask_presets(1, n_sims = 10000.4)$scheduler_vm_types,
+                   "Standard_E4s_v6")
+})
+
+test_that("mosaic_dask_presets() keeps D4s_v6 as the last worker vm_types fallback", {
+  # Coiled honours list order as decreasing priority, so D4s_v6 being LAST
+  # means it is only used when no D2 SKU is available. It is retained as an
+  # availability + RAM hedge.
+  spec <- mosaic_dask_presets(100)
+  expect_identical(spec$vm_types[length(spec$vm_types)], "Standard_D4s_v6")
+  expect_identical(spec$vm_types[1], "Standard_D2s_v6")
+})
+
+test_that("mosaic_io_presets() returns the documented shapes", {
+  expect_identical(mosaic_io_presets("debug")$format, "csv")
+  expect_identical(mosaic_io_presets("default")$compression, "zstd")
+  expect_identical(mosaic_io_presets("default")$compression_level, 3L)
+  expect_identical(mosaic_io_presets("archive")$compression_level, 9L)
+  expect_error(mosaic_io_presets("nope"))
+})


### PR DESCRIPTION
## Summary

Fixes the Coiled **scheduler** OOM (`Scheduler Stopped -> ... Out Of Memory (OOM) error (exit code 137)`). Builds directly on **@tinghf's #115** and adds one thing on top.

The scheduler is RAM-bound, not CPU-bound: the Dask calibration path submits **all** `n_sims` futures, holds every one alive, and gathers them in a **single blocking call**, so scheduler memory scales with `n_sims` (task graph + in-transit results), only weakly with `n_workers`.

## What's here

1. **From #115 (kept in full):** move the scheduler ladder to the memory-optimized **Ev6** family (Emerald Rapids, 8 GiB/vCPU vs Dsv6's 4). This is the right VM *shape* and directly fixes the observed 200-worker OOM (`D8s_v6` 32 GiB → `E16s_v6` 128 GiB).

   | tier | SKU | RAM |
   |---|---|---|
   | 1 | `Standard_E4s_v6` | 32 GiB |
   | 2 | `Standard_E8s_v6` | 64 GiB |
   | 3 | `Standard_E16s_v6` | 128 GiB |
   | 4 | `Standard_E32s_v6` | 256 GiB |
   | 5 | `Standard_E64s_v6` | 512 GiB |

2. **Added on top:** an optional `n_sims` arg (backward compatible, default `NULL`). Scheduler sized to `max(worker_tier, sim_tier)`, so a many-sims/few-workers batch — e.g. `mosaic_dask_presets(40, n_sims = 30000)` → **128 GiB** — is protected. A pure `n_workers` ladder gives that case only the tier-1 floor, which is the failure mode `n_sims` guards against.

3. **Regression test** `tests/testthat/test-presets.R` (53 pass): the 8 GiB `D2s_v6` scheduler must never be returned, and a many-sims/few-workers batch must lift the tier.

Worker `vm_types` unchanged; `D4s_v6` retained as the last-priority availability/RAM fallback.

## Relationship to #115

This **supersedes #115** — it contains @tinghf's Ev6 change verbatim plus the `n_sims` layer and a test. Suggest we close #115 in favor of this once @tinghf has reviewed. cc @tinghf

🤖 Generated with [Claude Code](https://claude.com/claude-code)