### PR TITLE
Fix stale laser_cholera underscore imports -> laser.cholera

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MOSAIC
 Type: Package
 Title: Metapopulation Outbreak Simulation And Interventions for Cholera (MOSAIC)
-Version: 0.64.0
+Version: 0.64.1
 Date: 2026-07-09
 Authors@R: c(
           person("John R", "Giles",

--- a/R/prefit_rolling_cv_psi.R
+++ b/R/prefit_rolling_cv_psi.R
@@ -272,7 +272,7 @@ prefit_rolling_cv_psi <- function(PATHS,
 #' @noRd
 .rcv_laser_version <- function() {
      v <- tryCatch({
-          lc <- reticulate::import("laser_cholera", delay_load = FALSE)
+          lc <- reticulate::import("laser.cholera", delay_load = FALSE)
           as.character(lc$`__version__`)
      }, error = function(e) NA_character_)
      if (length(v) != 1L || is.na(v)) NA_character_ else v

--- a/inst/examples/forecast_cv_experiment.R
+++ b/inst/examples/forecast_cv_experiment.R
@@ -305,7 +305,7 @@ if (PHASE %in% c("all", "score")) {
      manifest <- list(
           experiment = "forecast_cv (HINDCAST / conditional model skill, realized covariates -- NOT forecast skill)",
           created = as.character(Sys.time()), mosaic_version = as.character(utils::packageVersion("MOSAIC")),
-          laser_version = tryCatch(as.character(reticulate::py_to_r(reticulate::import("laser_cholera")$`__version__`)),
+          laser_version = tryCatch(as.character(reticulate::py_to_r(reticulate::import("laser.cholera")$`__version__`)),
                                    error = function(e) NA_character_),
           git_sha = tryCatch(system(paste("git -C", shQuote(file.path(root, "MOSAIC-pkg")), "rev-parse HEAD"), intern = TRUE),
                              error = function(e) NA_character_),


### PR DESCRIPTION
Follow-up to #117. Two best-effort laser-cholera version getters used the underscore module name `laser_cholera`, which raises `ModuleNotFoundError` (the reticulate module is the dotted `laser.cholera`, as used in `run_LASER.R`, `run_MOSAIC.R`, and `check_dependencies.R`). Both are wrapped in `tryCatch`, so the error was swallowed and they silently returned `NA` instead of the real engine version.

- `R/prefit_rolling_cv_psi.R:275` (`.rcv_laser_version`)
- `inst/examples/forecast_cv_experiment.R:308` (manifest `laser_version`)

Two-character fix each (`_` -> `.`). Version bump 0.64.0 -> 0.64.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)