### PR TITLE
Tt/scheduler oom fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: MOSAIC
 Type: Package
 Title: Metapopulation Outbreak Simulation And Interventions for Cholera (MOSAIC)
-Version: 0.64.2
-Date: 2026-07-09
+Version: 0.64.3
+Date: 2026-07-15
 Authors@R: c(
           person("John R", "Giles",
                  email = "john.giles@gatesfoundation.org",

--- a/R/run_MOSAIC_helpers.R
+++ b/R/run_MOSAIC_helpers.R
@@ -2401,18 +2401,27 @@
 #' Extract Per-Simulation Sampled Parameters
 #'
 #' Returns only the scalar/vector parameters that sample_parameters() modifies.
-#' Most matrix fields are excluded because they live in the broadcast
-#' base_config. However, psi_jt is INCLUDED here because
-#' .apply_psi_star_calibration() modifies it in-place per simulation -- the
-#' broadcast base_config has stale (uncalibrated) psi_jt.
+#' Matrix fields are excluded because they live either in the one-shot
+#' broadcast base_config (b_jt, d_jt, ...) or -- for psi_jt -- are shipped
+#' per-sim via a separate client$scatter() from .mosaic_run_batch_dask().
+#'
+#' Historical note: psi_jt was previously INCLUDED in this JSON because
+#' .apply_psi_star_calibration() recomputes it per-sim from psi_star_*
+#' scalars and the broadcast base_config carries the stale (uncalibrated)
+#' matrix. At ~2 MB per sim (40 loc x 3165 days x float64 at digits=NA)
+#' the inlined matrix pinned the scheduler task graph and caused linear
+#' scheduler-memory growth -> OOM on multi-country batches. Now psi_jt is
+#' scattered separately per sim; the Python worker receives it as an
+#' additional positional arg to run_laser_sim() and overrides the stale
+#' base_config psi_jt after _apply_sampled_params() (v0.64.3 fix).
 #' @noRd
 .extract_sampled_params <- function(params_sim) {
   # Exclude fields that are in the broadcast base_config AND are never
-  # modified by sample_parameters().  psi_jt is intentionally NOT excluded:
-  # .apply_psi_star_calibration() recalculates it per-sim using psi_star_*
-  # params, so the per-sim version must override the broadcast base_config.
+  # modified by sample_parameters(), plus psi_jt which is shipped per-sim
+  # via client$scatter() rather than inline in this JSON (see docstring
+  # above for rationale).
   base_fields <- c(
-    "b_jt", "d_jt", "mu_jt", "nu_1_jt", "nu_2_jt",
+    "b_jt", "d_jt", "mu_jt", "psi_jt", "nu_1_jt", "nu_2_jt",
     "reported_cases", "reported_deaths",
     # Per-cell confidence-weight matrices (config_default v4.1+). These are
     # broadcast in base_config via .extract_base_config() and are NEVER modified
@@ -2438,7 +2447,12 @@
 #' parallel::parLapply() cluster. Returns a list:
 #'   $params : the full sampled-config list (NULL on failure)
 #'   $json   : the per-sim JSON string ready for the Coiled worker
-#'             (NULL on failure)
+#'             (NULL on failure); does NOT include psi_jt (shipped
+#'             separately via client$scatter() from the parent -- see
+#'             .extract_sampled_params() docstring for rationale)
+#'   $psi_jt : the per-sim calibrated psi_jt matrix (R numeric matrix,
+#'             n_locations x n_time_steps) shipped separately via
+#'             client$scatter() from the parent; NULL on failure
 #'   $error  : NULL on success; a character message on failure
 #'
 #' Reproducibility: sample_parameters() takes `seed = sim_id` and is
@@ -2474,15 +2488,18 @@
     params <- .mosaic_clamp_transmission_params(params)
 
     # Serialize the sampled (non-base) fields for shipping to the Coiled worker.
+    # psi_jt is EXCLUDED from this JSON (see .extract_sampled_params docstring)
+    # and returned separately so the parent can client$scatter() it.
     json <- jsonlite::toJSON(
       .extract_sampled_params(params),
       auto_unbox = TRUE,
       digits     = NA
     )
 
-    list(params = params, json = as.character(json), error = NULL)
+    list(params = params, json = as.character(json),
+         psi_jt = params$psi_jt, error = NULL)
   }, error = function(e) {
-    list(params = NULL, json = NULL, error = conditionMessage(e))
+    list(params = NULL, json = NULL, psi_jt = NULL, error = conditionMessage(e))
   })
 }
 
@@ -2777,6 +2794,7 @@
     map_indices  <- integer(0)    # positions in params_list/futures
     map_sim_ids  <- integer(0)
     map_jsons    <- character(0)
+    map_psis     <- list()        # per-sim psi_jt matrices; scattered below
 
     for (k in seq_along(chunk_indices)) {
       idx <- chunk_indices[k]
@@ -2802,22 +2820,48 @@
 
       params_list[[idx]] <- r$params
       if (is.null(r$params) || is.null(r$json)) next
+      # psi_jt is required (shipped via scatter, not JSON) -- skip loudly
+      # if missing so we never dispatch a task that would silently use the
+      # stale base_config psi_jt on the worker. In production configs
+      # sample_parameters() always populates params$psi_jt; a NULL here
+      # signals a malformed config.
+      if (is.null(r$psi_jt)) {
+        warning("sim ", sim_ids[idx], ": params$psi_jt is NULL after ",
+                "sampling; skipping (config likely missing psi_jt matrix)",
+                call. = FALSE, immediate. = FALSE)
+        next
+      }
 
       map_indices <- c(map_indices, idx)
       map_sim_ids <- c(map_sim_ids, as.integer(sim_ids[idx]))
       map_jsons   <- c(map_jsons, r$json)
+      map_psis[[length(map_psis) + 1L]] <- r$psi_jt
     }
 
     # --- Submit entire chunk via client$map() (single scheduler round-trip).
     # The Coiled client lives in the parent process only; submission MUST
     # stay outside the parallel block.
     if (length(map_sim_ids) > 0L) {
+      # Batch-scatter this chunk's per-sim psi_jt matrices in a SINGLE
+      # scheduler RPC (not one per sim). Each matrix (~40 loc x 3165 days,
+      # ~2 MB float64) is thereby stored on a worker, and the task-graph
+      # entry we ship to the scheduler in client$map() below carries only a
+      # Future reference (~bytes). Historically psi_jt was embedded in
+      # map_jsons and pinned ~2 MB per task in the scheduler's task graph
+      # until gather(), OOMing the scheduler on multi-country batches
+      # (Coiled scheduler linear-memory-growth incident, v0.64.3 fix).
+      # hash = FALSE skips content-hashing dedup (per-sim payloads are
+      # always distinct after psi_star calibration).
+      psi_py_list <- reticulate::r_to_py(map_psis)
+      psi_futures <- client$scatter(psi_py_list, hash = FALSE)
+
       chunk_futures <- client$map(
         mosaic_worker$run_laser_sim,
         as.list(map_sim_ids),
         as.list(rep(as.integer(n_iterations), length(map_sim_ids))),
         as.list(map_jsons),
-        as.list(rep(list(base_config_future), length(map_sim_ids)))
+        as.list(rep(list(base_config_future), length(map_sim_ids))),
+        as.list(psi_futures)
       )
       for (fi in seq_along(map_indices)) {
         futures[[ map_indices[fi] ]] <- chunk_futures[[fi]]

--- a/inst/python/mosaic_dask_worker.py
+++ b/inst/python/mosaic_dask_worker.py
@@ -156,11 +156,15 @@ def _apply_sampled_params(base_config: dict, sampled_params_json: str) -> dict:
     etc.) because it was created via reticulate::r_to_py() and then scattered
     via client.scatter().
 
-    psi_jt is a special case: apply_psi_star_calibration() in R recalculates
-    it per-sim using the sampled psi_star_* params, so the updated psi_jt is
-    sent via JSON per-sim and must override the stale broadcast copy.  It
-    arrives as a list-of-lists (rows × cols) and is converted to a 2-D numpy
-    array here.
+    psi_jt handling: prior to v0.64.3 the per-sim calibrated psi_jt was
+    embedded in sampled_params_json and overwrote the stale broadcast copy
+    here. That caused ~2 MB per-task inlining into the scheduler's task
+    graph and OOMed the scheduler on multi-country batches. As of v0.64.3
+    psi_jt is shipped separately via client.scatter() and injected in the
+    caller (run_laser_sim) AFTER this function returns -- see that
+    function's docstring. The list-of-lists -> 2-D-array conversion below
+    is retained as a safety net for any legacy JSON that still carries
+    psi_jt (no-op when it doesn't).
 
     A deep copy of base_config is made to prevent mutation of the scattered
     object across simulations on the same worker.
@@ -416,7 +420,8 @@ def get_engine_versions() -> dict:
 
 
 def run_laser_sim(sim_id: int, n_iterations: int,
-                  sampled_params_json: str, base_config: dict) -> dict:
+                  sampled_params_json: str, base_config: dict,
+                  psi_jt) -> dict:
     """
     Run a single MOSAIC simulation on a Dask worker.
 
@@ -432,11 +437,22 @@ def run_laser_sim(sim_id: int, n_iterations: int,
     sampled_params_json : str
         JSON string of scalar/vector parameters sampled for this simulation
         (output of R's .extract_sampled_params()). Does NOT include matrix
-        fields — those live in base_config.
+        fields — those live in base_config, EXCEPT for psi_jt which is
+        shipped separately via the ``psi_jt`` parameter below (client-side
+        client.scatter() -> Future reference in the task spec, so the
+        scheduler task graph doesn't carry ~2 MB per sim).
     base_config : dict
         Scattered base config dict (reticulate-converted from R). Contains
-        numpy 2-D arrays for b_jt, d_jt, psi_jt, etc., plus fixed scalars
-        like date_start, location_name, N_j_initial, etc.
+        numpy 2-D arrays for b_jt, d_jt, psi_jt (STALE / uncalibrated -- see
+        ``psi_jt`` below), nu_1_jt, nu_2_jt, etc., plus fixed scalars like
+        date_start, location_name, N_j_initial, etc.
+    psi_jt : numpy.ndarray or list-of-lists
+        Per-simulation calibrated psi_jt matrix (n_locations x n_time_steps).
+        Shipped separately via a per-sim client.scatter() from the R
+        orchestrator to avoid inlining ~2 MB per task into the scheduler's
+        task graph (v0.64.3 fix for the Coiled scheduler linear-memory-
+        growth OOM). Overrides the stale base_config['psi_jt'] on this
+        worker after _apply_sampled_params() runs.
 
     Returns
     -------
@@ -487,6 +503,19 @@ def run_laser_sim(sim_id: int, n_iterations: int,
         )
 
         config = _apply_sampled_params(base_config, sampled_params_json)
+
+        # Override the stale broadcast psi_jt with the per-sim calibrated
+        # matrix shipped via client.scatter(). psi_jt is excluded from
+        # sampled_params_json (would inline ~2 MB per task into the
+        # scheduler's task graph and OOM the scheduler on multi-country
+        # batches -- v0.64.3 fix). Fail loud if the caller didn't send it.
+        if psi_jt is None:
+            raise ValueError(
+                "run_laser_sim: psi_jt argument is required (was None). "
+                "The R orchestrator must scatter the per-sim calibrated "
+                "psi_jt and pass the Future as the 5th client.map arg."
+            )
+        config["psi_jt"] = np.asarray(psi_jt, dtype=np.float64)
 
         # The sampled dict (minus matrix fields) is echoed back so the R
         # gather adapter can flatten it into parquet columns without

--- a/tests/testthat/test-dask_worker_schema_parity.R
+++ b/tests/testthat/test-dask_worker_schema_parity.R
@@ -346,9 +346,14 @@ test_that(".mosaic_sample_and_serialize captures errors instead of throwing", {
   )
 
   expect_type(bad_result, "list")
-  expect_named(bad_result, c("params", "json", "error"))
+  # psi_jt was added to the return contract in v0.64.3 (shipped via
+  # client$scatter() instead of inline in $json to fix the Coiled
+  # scheduler task-graph OOM). On the error path it must still be NULL
+  # like $params/$json so callers can uniformly detect failure.
+  expect_named(bad_result, c("params", "json", "psi_jt", "error"))
   expect_null(bad_result$params)
   expect_null(bad_result$json)
+  expect_null(bad_result$psi_jt)
   expect_type(bad_result$error, "character")
   expect_true(nzchar(bad_result$error))
 })

--- a/tests/testthat/test-dask_worker_score_window_parity.R
+++ b/tests/testthat/test-dask_worker_score_window_parity.R
@@ -180,7 +180,14 @@ test_that("Dask worker _apply_sampled_params preserves engine as_ndarray dtypes 
   testthat::expect_null(ser$error)
 
   # Worker config (numpy/list mix) and the local-path config (r_to_py lists).
+  # As of v0.64.3 the Dask path ships psi_jt via a separate client.scatter()
+  # rather than inline in ser$json; run_laser_sim() injects it into the
+  # config AFTER _apply_sampled_params() returns. Mirror that here so this
+  # test exercises the same effective config the production worker sees --
+  # otherwise config_w keeps the stale (uncalibrated) base_config psi_jt
+  # and diverges from config_lp end-to-end.
   config_w  <- reticulate::py$`_apply_sampled_params`(base_py, ser$json)
+  config_w[["psi_jt"]] <- reticulate::r_to_py(ser$psi_jt)
   config_lp <- reticulate::r_to_py(
     MOSAIC:::.mosaic_prepare_config_for_python(ser$params)
   )


### PR DESCRIPTION
Avoid scheduler OOM by: keep psi_jt out of the per-sim JSON and batch-scatter it per chunk instead, so task specs carry only Future references (~bytes each) while the ~2 MB matrix lives on a worker. 